### PR TITLE
update urlpatterns and BASE_ACCOUNTS* url settings

### DIFF
--- a/base_accounts/forms.py
+++ b/base_accounts/forms.py
@@ -9,7 +9,7 @@ class SignupFormMixin(object):
 
     def clean_email(self, *args, **kwargs):
         data = self.cleaned_data['email']
-        if self.clean_email_user_model:
+        if getattr(self, 'clean_email_user_model', None):
             model = self.clean_email_user_model
         else:
             model = self.user_model

--- a/base_accounts/urls.py
+++ b/base_accounts/urls.py
@@ -1,15 +1,20 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
-from base_accounts.views import LoginFormView, SignupFormView, LogoutView, UpdateEmailFormView, UpdatePasswordFormView, PostLoginRedirectView
+from base_accounts.views import LoginFormView
+from base_accounts.views import LogoutView
+from base_accounts.views import PostLoginRedirectView
+from base_accounts.views import SignupFormView
+from base_accounts.views import UpdateEmailFormView
+from base_accounts.views import UpdatePasswordFormView
+from base_accounts.views import confirm_email_address
 
 
-urlpatterns = patterns(
-    'base_accounts.views',
+urlpatterns = [
     url(r'^login/$', LoginFormView.as_view(), name='login'),
     url(r'^post-login/$', PostLoginRedirectView.as_view(), name='post_login'),
     url(r'^signup/$', SignupFormView.as_view(), name='signup'),
     url(r'^settings/email/$', login_required(UpdateEmailFormView.as_view()), name='settings_update_email'),
     url(r'^settings/password/$', login_required(UpdatePasswordFormView.as_view()), name='settings_update_password'),
-    url(r'^confirmar/(?P<token>.+)/', 'confirm_email_address', name='confirm_email_address'),
+    url(r'^confirm/(?P<token>.+)/', confirm_email_address, name='confirm_email_address'),
     url(r'^logout/$', login_required(LogoutView.as_view()), name="logout"),
-)
+]

--- a/base_accounts/views.py
+++ b/base_accounts/views.py
@@ -209,7 +209,7 @@ class PostLoginRedirectView(SuccessMessageMixin, View):
         if self.request.GET.get('next'):
             self.success_url = self.request.GET.get('next')
         messages.success(self.request, self.success_message)
-        return redirect(self.success_url)
+        return redirect(self.get_success_url())
 
 
 class LogoutView(View):
@@ -229,7 +229,7 @@ class LogoutView(View):
             user.first_login = False
             user.save(update_fields=['first_login'])
         logout(request)
-        return redirect(self.success_url)
+        return redirect(self.get_success_url())
 
 
 def confirm_email_address(request, token):

--- a/base_accounts/views.py
+++ b/base_accounts/views.py
@@ -201,8 +201,7 @@ class PostLoginRedirectView(SuccessMessageMixin, View):
         success_url = getattr(settings,
                               'BASE_ACCOUNTS_POST_LOGIN_REDIRECT_URL',
                               settings.LOGIN_REDIRECT_URL)
-        self.success_url = resolve_url(success_url)
-        return super(PostLoginRedirectView, self).get_success_url()
+        return resolve_url(success_url)
 
     def dispatch(self, request, *args, **kwargs):
         """Override post-login url if provided"""
@@ -219,8 +218,7 @@ class LogoutView(View):
         success_url = getattr(settings,
                               'BASE_ACCOUNTS_LOGOUT_REDIRECT_URL',
                               '/')
-        self.success_url = resolve_url(success_url)
-        return super(LogoutView, self).get_success_url()
+        return resolve_url(success_url)
 
     def dispatch(self, request, *args, **kwargs):
         list(messages.get_messages(request))  # Get rid of messages

--- a/base_accounts/views.py
+++ b/base_accounts/views.py
@@ -195,8 +195,14 @@ class UpdatePasswordFormView(SuccessMessageMixin, ErrorMessageRedirectMixin, For
 
 class PostLoginRedirectView(SuccessMessageMixin, View):
     """Used by social login flows (e.g. OAuth)"""
-    success_url = getattr(settings, 'BASE_ACCOUNTS_POST_LOGIN_REDIRECT_URL', settings.LOGIN_REDIRECT_URL)
     success_message = _("You have logged in")
+
+    def get_success_url(self):
+        success_url = getattr(settings,
+                              'BASE_ACCOUNTS_POST_LOGIN_REDIRECT_URL',
+                              settings.LOGIN_REDIRECT_URL)
+        self.success_url = resolve_url(success_url)
+        return super(PostLoginRedirectView, self).get_success_url()
 
     def dispatch(self, request, *args, **kwargs):
         """Override post-login url if provided"""
@@ -208,7 +214,13 @@ class PostLoginRedirectView(SuccessMessageMixin, View):
 
 class LogoutView(View):
     """Updates User.first_login field before logout"""
-    success_url = getattr(settings, 'BASE_ACCOUNTS_LOGOUT_REDIRECT_URL', '/')
+
+    def get_success_url(self):
+        success_url = getattr(settings,
+                              'BASE_ACCOUNTS_LOGOUT_REDIRECT_URL',
+                              '/')
+        self.success_url = resolve_url(success_url)
+        return super(LogoutView, self).get_success_url()
 
     def dispatch(self, request, *args, **kwargs):
         list(messages.get_messages(request))  # Get rid of messages

--- a/base_accounts/views.py
+++ b/base_accounts/views.py
@@ -10,7 +10,7 @@ from django.utils.timezone import now
 from django.conf import settings
 from django.http import Http404
 from django.core import signing
-from django.core.urlresolvers import reverse_lazy
+from django.core.urlresolvers import reverse
 from django.contrib.auth import get_user_model
 
 from base_accounts.forms import SignupForm, LoginForm, UpdateEmailForm, UpdatePasswordForm
@@ -124,15 +124,21 @@ class UpdateEmailFormView(SuccessMessageMixin, ErrorMessageRedirectMixin, FormVi
     """Updates user model with new provided email"""
     form_class = UpdateEmailForm
     template_name = 'base_accounts/update_email.html'
-    success_url = getattr(settings, 'BASE_ACCOUNTS_UPDATE_EMAIL_REDIRECT_URL', reverse_lazy('settings_update_email'))
-    error_url = getattr(settings, 'BASE_ACCOUNTS_UPDATE_EMAIL_ERROR_REDIRECT_URL', reverse_lazy('settings_update_email'))
     success_message = _('You have updated your email successfully')
 
     def get_success_url(self):
-        url_setting = getattr(settings,
-                              'BASE_ACCOUNTS_LOGIN_REDIRECT_URL',
-                              settings.LOGIN_REDIRECT_URL)
-        return resolve_url(url_setting)
+        success_url = getattr(settings,
+                              'BASE_ACCOUNTS_UPDATE_EMAIL_REDIRECT_URL',
+                              reverse('settings_update_email'))
+        self.success_url = resolve_url(success_url)
+        return super(UpdateEmailFormView, self).get_success_url()
+
+    def get_error_url(self):
+        error_url = getattr(settings,
+                            'BASE_ACCOUNTS_UPDATE_EMAIL_ERROR_REDIRECT_URL',
+                            reverse('settings_update_email'))
+        self.error_url = resolve_url(error_url)
+        return super(UpdateEmailFormView, self).get_error_url()
 
     def get_form_kwargs(self):
         """Form uses request to fetch current user"""
@@ -153,9 +159,21 @@ class UpdatePasswordFormView(SuccessMessageMixin, ErrorMessageRedirectMixin, For
     """Updates user model with new provided password"""
     form_class = UpdatePasswordForm
     template_name = 'base_accounts/update_password.html'
-    success_url = getattr(settings, 'BASE_ACCOUNTS_UPDATE_PASSWORD_REDIRECT_URL', reverse_lazy('settings_update_password'))
-    error_url = getattr(settings, 'BASE_ACCOUNTS_UPDATE_PASSWORD_ERROR_REDIRECT_URL', reverse_lazy('settings_update_password'))
     success_message = _('You have updated your password successfully')
+
+    def get_success_url(self):
+        success_url = getattr(settings,
+                              'BASE_ACCOUNTS_UPDATE_PASSWORD_REDIRECT_URL',
+                              reverse('settings_update_password'))
+        self.success_url = resolve_url(success_url)
+        return super(UpdatePasswordFormView, self).get_success_url()
+
+    def get_error_url(self):
+        error_url = getattr(settings,
+                            'BASE_ACCOUNTS_UPDATE_PASSWORD_ERROR_REDIRECT_URL',
+                            reverse('settings_update_password'))
+        self.error_url = resolve_url(error_url)
+        return super(UpdatePasswordFormView, self).get_error_url()
 
     def get_form_kwargs(self):
         """Form uses request to fetch current user"""


### PR DESCRIPTION
Old style urlpatterns are deprecated and will be removed in Django 1.10. Replacing view names with callables is totally fine and doesn't break compatibility for older versions of Django.

A minor change is included to also accept view names on BASE_ACCOUNTS\* url settings. Like Django, accepts a string and tries to resolve it to a view name or a view python path. If it can't resolve it, just passes the url as is.

This enhances flexibility and leaves django-nomad-base-accounts on par with new Django versions that behave like this for LOGIN_URL and friends.
